### PR TITLE
Allow body and endpoint to both be functions in createApiAction

### DIFF
--- a/src/createApiAction.js
+++ b/src/createApiAction.js
@@ -36,6 +36,18 @@ export default (name, endpoint, method, body, headers, rest) => {
           }
         }
     }
+  } else if (typeof endpoint === 'function' && typeof body === 'function') {
+    return function () {
+      return {
+        type: 'CALL_API',
+        CALL_API: {
+          types: [`${name}_REQUEST`, `${name}_SUCCESS`, `${name}_FAILURE`],
+          endpoint: endpoint(...arguments),
+          method: method,
+          body: body(...arguments)
+        }
+      }
+    }
   } else {
     return function () {
         return {

--- a/tests/createApiActionTest.js
+++ b/tests/createApiActionTest.js
@@ -2,7 +2,7 @@ import { expect } from 'chai'
 import createApiAction from '../src/createApiAction'
 import _ from 'lodash'
 
-describe('random test', () => {
+describe('createApiAction', () => {
 	it('should make get call', () => {
 		let expected = {
 			type: 'CALL_API',
@@ -23,14 +23,35 @@ describe('random test', () => {
 				types: ['A_REQUEST', 'A_SUCCESS', 'A_FAILURE'],
 				endpoint: 'foo',
 				method: 'get',
-				body: {"foo": "foo"},
+				body: {'foo': 'foo'},
 				headers: {
 					'Content-Type': 'application/json'
 				}
 			}
 		}
-		let fooCreator = createApiAction('A', 'foo', 'get', {"foo": "foo"})
+		let fooCreator = createApiAction('A', 'foo', 'get', {'foo': 'foo'})
 		let created = fooCreator()
+		expect(expected).to.eql(created)
+	})
+
+	it('should allow both body and endpoint to be functions', () => {
+		let expected = {
+			type: 'CALL_API',
+			CALL_API: {
+				types: ['A_REQUEST', 'A_SUCCESS', 'A_FAILURE'],
+				endpoint: 'api/test',
+				method: 'post',
+				body: { value: 'hello' }
+			}
+		}
+
+		let fooCreator = createApiAction(
+			'A',
+			address => `api/${address}`,
+			'post',
+			(address, value) => ({ value: value })
+		)
+		let created = fooCreator('test', 'hello')
 		expect(expected).to.eql(created)
 	})
 })


### PR DESCRIPTION
Adds a check in `createApiAction` to see if `endpoint` and `body` are both functions, and if so passes parameters to them. This is useful in situations where both the endpoint and values can be dynamic.